### PR TITLE
Update link creation to hack in HTTPS for root links and item links

### DIFF
--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -386,12 +386,14 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                 )
 
             links = []
+            base = kwargs['request'].base_url
+            base_corrected = str(base).replace('http://', 'https://')
             if page.next:
                 links.append(
                     {
                         "rel": Relations.next.value,
                         "type": "application/geo+json",
-                        "href": f"{kwargs['request'].base_url}search",
+                        "href": f"{base_corrected}search",
                         "method": "POST",
                         "body": {"token": page.next},
                         "merge": True,
@@ -402,7 +404,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     {
                         "rel": Relations.previous.value,
                         "type": "application/geo+json",
-                        "href": f"{kwargs['request'].base_url}search",
+                        "href": f"{base_corrected}search",
                         "method": "POST",
                         "body": {"token": page.previous},
                         "merge": True,

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -239,6 +239,10 @@ class LandingPageMixin(abc.ABC):
         conformance_classes: List[str],
         extension_schemas: List[str],
     ) -> stac_types.LandingPage:
+
+        # TODO fix this: we need to be able to use https, at least make this configurable
+        base_url = base_url.replace("http://", "https://")
+
         landing_page = stac_types.LandingPage(
             type="Catalog",
             id=self.landing_page_id,
@@ -346,6 +350,8 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ]
         request: Request = kwargs["request"]
         base_url = str(request.base_url)
+        # TODO fix this: we need to be able to use https, at least make this configurable
+        base_url = base_url.replace("http://", "https://")
         landing_page = self._landing_page(
             base_url=base_url,
             conformance_classes=self.conformance_classes(),
@@ -520,6 +526,10 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         """
         request: Request = kwargs["request"]
         base_url = str(request.base_url)
+
+        # TODO fix this: we need to be able to use https, at least make this configurable
+        base_url = base_url.replace("http://", "https://")
+
         extension_schemas = [
             schema.schema_href for schema in self.extensions if schema.schema_href
         ]

--- a/stac_fastapi/types/stac_fastapi/types/links.py
+++ b/stac_fastapi/types/stac_fastapi/types/links.py
@@ -9,7 +9,7 @@ from stac_pydantic.shared import MimeTypes
 
 # These can be inferred from the item/collection so they aren't included in the database
 # Instead they are dynamically generated when querying the database using the classes defined below
-INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root"]
+INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root", "next"]
 
 
 def filter_links(links: List[Dict]) -> List[Dict]:
@@ -34,7 +34,10 @@ class BaseLinks:
 
     def root(self) -> Dict[str, Any]:
         """Return the catalog root."""
-        return dict(rel=Relations.root, type=MimeTypes.json, href=self.base_url)
+        return dict(rel=Relations.root, type=MimeTypes.json, href=self.base_url.replace('http://', 'https://'))
+
+    def next(self) -> Dict[str, Any]:
+        return dict(rel=Relations.next, type=MimeTypes.json, href=self.base_url.replace('http://', 'https://'))
 
 
 @attr.s
@@ -46,19 +49,19 @@ class CollectionLinks(BaseLinks):
         return dict(
             rel=Relations.self,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url.replace('http://', 'https://'), f"collections/{self.collection_id}"),
         )
 
     def parent(self) -> Dict[str, Any]:
         """Create the `parent` link."""
-        return dict(rel=Relations.parent, type=MimeTypes.json, href=self.base_url)
+        return dict(rel=Relations.parent, type=MimeTypes.json, href=self.base_url.replace('http://', 'https://'))
 
     def items(self) -> Dict[str, Any]:
         """Create the `items` link."""
         return dict(
             rel="items",
             type=MimeTypes.geojson,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}/items"),
+            href=urljoin(self.base_url.replace('http://', 'https://'), f"collections/{self.collection_id}/items"),
         )
 
     def create_links(self) -> List[Dict[str, Any]]:
@@ -78,9 +81,9 @@ class ItemLinks(BaseLinks):
             rel=Relations.self,
             type=MimeTypes.geojson,
             href=urljoin(
-                self.base_url,
+                self.base_url.replace('http://', 'https://'),
                 f"collections/{self.collection_id}/items/{self.item_id}",
-            ),
+            )
         )
 
     def parent(self) -> Dict[str, Any]:
@@ -88,7 +91,7 @@ class ItemLinks(BaseLinks):
         return dict(
             rel=Relations.parent,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url.replace('http://', 'https://'), f"collections/{self.collection_id}"),
         )
 
     def collection(self) -> Dict[str, Any]:
@@ -96,7 +99,7 @@ class ItemLinks(BaseLinks):
         return dict(
             rel=Relations.collection,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url.replace('http://', 'https://'), f"collections/{self.collection_id}"),
         )
 
     def tiles(self) -> Dict[str, Any]:
@@ -106,9 +109,9 @@ class ItemLinks(BaseLinks):
             type=MimeTypes.json,
             title="tiles",
             href=urljoin(
-                self.base_url,
+                self.base_url.replace('http://', 'https://'),
                 f"collections/{self.collection_id}/items/{self.item_id}/tiles",
-            ),
+            )
         )
 
     def create_links(self) -> List[Dict[str, Any]]:
@@ -118,6 +121,7 @@ class ItemLinks(BaseLinks):
             self.parent(),
             self.collection(),
             self.root(),
+            self.next()
         ]
         # if config.settings.add_on_is_enabled(config.AddOns.tiles):
         # TODO: Don't always append tiles link


### PR DESCRIPTION
Changes in the types/links module alter the item links but in terms of pagination, won't have any affect.

sqlalchemy/core module is what seems to build the links used for the item collection but I don't know if there's a better way of doing so.


**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).